### PR TITLE
Implement more commands, load quest data

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -178,7 +178,7 @@ namespace Destiny
         AddPreventSlipping = 0x02,
         AddPreventColdness = 0x04,
         Untradeable = 0x08,
-        Scisored = 0x10
+        Scissored = 0x10
     }
 
     public enum ItemType : byte
@@ -189,6 +189,32 @@ namespace Destiny
         Etcetera = 4,
         Cash = 5,
         Count = 6
+    }
+
+    public enum QuestAction : byte
+    {
+        RestoreLostItem,
+        Start,
+        Complete,
+        Forfeit,
+        ScriptStart,
+        ScriptEnd
+    }
+
+    [Flags]
+    public enum QuestFlags : short
+    {
+        //TODO: Test this; I'm just guessing
+        AutoStart = 0x01,
+        SelectedMob = 0x02
+    }
+
+    public enum QuestStatus : short
+    {
+        Forfeited = -1,
+        NotStarted = 0,
+        InProgress = 1,
+        Complete = 2
     }
 
     public enum Gender : byte

--- a/src/Core/Network/OpCodes.cs
+++ b/src/Core/Network/OpCodes.cs
@@ -186,7 +186,7 @@
         CashShopOperation = 0xDA,
         BuyCashItem = 0xDB,
         CouponCode = 0xDC,
-        Disconnect = 0xDF,
+        LeaveField = 0xDF,
         OpenItemInterface = 0xE1,
         CloseItemInterface = 0xE2,
         UseItemInterface = 0xE3,

--- a/src/Destiny.csproj
+++ b/src/Destiny.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Maple\Data\AvailableStyles.cs" />
     <Compile Include="Maple\Data\CachedItems.cs" />
     <Compile Include="Maple\Data\CachedMaps.cs" />
+    <Compile Include="Maple\Data\CachedQuests.cs" />
     <Compile Include="Maple\Data\DataProvider.cs" />
     <Compile Include="Maple\InventoryOperation.cs" />
     <Compile Include="Maple\Life\LifeObject.cs" />
@@ -88,6 +89,7 @@
     <Compile Include="Maple\Maps\MapSpawnPoints.cs" />
     <Compile Include="Maple\Meso.cs" />
     <Compile Include="Maple\NoAccountException.cs" />
+    <Compile Include="Maple\Quest.cs" />
     <Compile Include="Maple\Script\NpcScript.cs" />
     <Compile Include="Maple\Script\PortalScript.cs" />
     <Compile Include="Maple\Script\ScriptBase.cs" />

--- a/src/Maple/Characters/CharacterItems.cs
+++ b/src/Maple/Characters/CharacterItems.cs
@@ -109,7 +109,7 @@ namespace Destiny.Maple.Characters
                             .WriteByte(1)
                             .WriteByte((byte)InventoryOperationType.AddItem)
                             .WriteByte((byte)item.Type)
-                            .WriteByte((byte)item.Slot);
+                            .WriteShort(item.Slot);
 
                         item.Encode(oPacket, true);
 

--- a/src/Maple/Commands/Implementation/ItemCommand.cs
+++ b/src/Maple/Commands/Implementation/ItemCommand.cs
@@ -38,15 +38,10 @@ namespace Destiny.Maple.Commands
             else
             {
                 short quantity = 0;
-                bool isQuantitySpecified;
 
                 if (args.Length > 1)
                 {
-                    isQuantitySpecified = short.TryParse(args[args.Length - 1], out quantity);
-                }
-                else
-                {
-                    isQuantitySpecified = false;
+                    short.TryParse(args[args.Length - 1], out quantity);
                 }
 
                 if (quantity < 1)

--- a/src/Maple/Commands/Implementation/MapCommand.cs
+++ b/src/Maple/Commands/Implementation/MapCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Destiny.Maple.Characters;
+using Destiny.Maple.Data;
 using Destiny.Network;
 using System;
 
@@ -54,21 +55,17 @@ namespace Destiny.Maple.Commands
                         byte.TryParse(args[1], out portalID);
                     }
 
-                    if(mapID > -1)
+                    //TODO: Add aliases
+                    if (mapID > -1)
                     {
-                        //TODO: Add aliases
-                        try
-                        {
+                        if(DataProvider.CachedMaps.Contains(mapID))
                             caller.ChangeMap(mapID, portalID);
-                        }
-                        catch(Exception)
-                        {
-                            caller.Notify(string.Format("Invalid map ID {0}.", mapID));
-                        }
+                        else
+                            caller.Notify(string.Format("[Command] Invalid map ID {0}.", mapID));
                     }
                     else
                     {
-                        caller.Notify(string.Format("Invalid map '{0}'.", args[0]));
+                        caller.Notify(string.Format("[Command] Invalid map '{0}'.", args[0]));
                     }
                 }
             }

--- a/src/Maple/Commands/Implementation/NoticeCommand.cs
+++ b/src/Maple/Commands/Implementation/NoticeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Destiny.Maple.Characters;
+using Destiny.Network;
 
 namespace Destiny.Maple.Commands
 {
@@ -30,7 +31,23 @@ namespace Destiny.Maple.Commands
 
         public override void Execute(Character caller, string[] args)
         {
-
+            if (args.Length < 1)
+            {
+                this.ShowSyntax(caller);
+            }
+            else
+            {
+                foreach (ChannelServer channel in MasterServer.Channels)
+                {
+                    lock (channel.Clients)
+                    {
+                        foreach (MapleClient client in channel.Clients)
+                        {
+                            client.Character.Notify(args[0], NoticeType.Notice);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Maple/Commands/Implementation/TickerCommand.cs
+++ b/src/Maple/Commands/Implementation/TickerCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Destiny.Maple.Characters;
+using Destiny.Network;
 
 namespace Destiny.Maple.Commands
 {
@@ -16,7 +17,7 @@ namespace Destiny.Maple.Commands
         {
             get
             {
-                return "message";
+                return "[ message ]";
             }
         }
 
@@ -30,7 +31,18 @@ namespace Destiny.Maple.Commands
 
         public override void Execute(Character caller, string[] args)
         {
+            string message = args.Length > 0 ? args[0] : string.Empty;
 
+            foreach (ChannelServer channel in MasterServer.Channels)
+            {
+                lock (channel.Clients)
+                {
+                    foreach (MapleClient client in channel.Clients)
+                    {
+                        client.Character.Notify(message, NoticeType.Ticker);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Maple/Data/CachedQuests.cs
+++ b/src/Maple/Data/CachedQuests.cs
@@ -1,0 +1,30 @@
+﻿using Destiny.Data;
+using Destiny.Maple.Life;
+using Destiny.Maple.Maps;
+using System.Collections.ObjectModel;
+
+namespace Destiny.Maple.Data
+{
+    public sealed class CachedQuests : KeyedCollection<int, Quest>
+    {
+        public CachedQuests()
+            : base()
+        {
+            using (Log.Load("Quests"))
+            {
+                foreach (Datum datum in new Datums("quest_data").Populate())
+                {
+                    Datums requests = new Datums("quest_requests").Populate("questid = '{0}'", datum["questid"]);
+                    Datums rewards = new Datums("quest_rewards").Populate("questid = '{0}'", datum["questid"]);
+                    Datums jobs = new Datums("quest_required_jobs").Populate("questid = '{0}'", datum["questid"]);
+                    this.Add(new Quest(datum, requests, rewards, jobs));
+                }
+            }
+        }
+
+        protected override int GetKeyForItem(Quest item)
+        {
+            return item.MapleID;
+        }
+    }
+}

--- a/src/Maple/Data/DataProvider.cs
+++ b/src/Maple/Data/DataProvider.cs
@@ -11,6 +11,7 @@ namespace Destiny.Maple.Data
         public static AvailableStyles AvailableStyles { get; private set; }
         public static CachedItems CachedItems { get; private set; }
         public static CachedMaps CachedMaps { get; private set; }
+        public static CachedQuests CachedQuests { get; private set; }
 
         public static void Initialize()
         {
@@ -27,6 +28,7 @@ namespace Destiny.Maple.Data
                 DataProvider.AvailableStyles = new AvailableStyles();
                 DataProvider.CachedItems = new CachedItems();
                 DataProvider.CachedMaps = new CachedMaps();
+                DataProvider.CachedQuests = new CachedQuests();
 
                 CommandFactory.Initialize();
 

--- a/src/Maple/Item.cs
+++ b/src/Maple/Item.cs
@@ -30,7 +30,7 @@ namespace Destiny.Maple
         public bool PreventsSlipping { get; private set; }
         public bool PreventsColdness { get; private set; }
         public bool IsTradeBlocked { get; private set; }
-        public bool IsScisored { get; private set; }
+        public bool IsScissored { get; private set; }
         public int SalePrice { get; private set; }
 
         public byte UpgradesAvailable { get; private set; }
@@ -202,7 +202,7 @@ namespace Destiny.Maple
                 if (this.IsSealed) flags |= (byte)ItemFlags.Sealed;
                 if (this.PreventsSlipping) flags |= (byte)ItemFlags.AddPreventSlipping;
                 if (this.PreventsColdness) flags |= (byte)ItemFlags.AddPreventColdness;
-                if (this.IsScisored) flags |= (byte)ItemFlags.Scisored;
+                if (this.IsScissored) flags |= (byte)ItemFlags.Scissored;
                 if (this.IsTradeBlocked) flags |= (byte)ItemFlags.Untradeable;
 
                 return flags;
@@ -341,7 +341,7 @@ namespace Destiny.Maple
         {
             get
             {
-                return this.IsCash || this.IsSealed || (this.IsTradeBlocked && !this.IsScisored);
+                return this.IsCash || this.IsSealed || (this.IsTradeBlocked && !this.IsScissored);
             }
         }
 
@@ -392,7 +392,7 @@ namespace Destiny.Maple
             this.IsCash = this.CachedReference.IsCash;
             this.OnlyOne = this.CachedReference.OnlyOne;
             this.IsTradeBlocked = this.CachedReference.IsTradeBlocked;
-            this.IsScisored = this.CachedReference.IsScisored;
+            this.IsScissored = this.CachedReference.IsScissored;
             this.SalePrice = this.CachedReference.SalePrice;
             this.RequiredLevel = this.CachedReference.RequiredLevel;
 
@@ -448,7 +448,7 @@ namespace Destiny.Maple
                 this.IsCash = this.CachedReference.IsCash;
                 this.OnlyOne = this.CachedReference.OnlyOne;
                 this.IsTradeBlocked = this.CachedReference.IsTradeBlocked;
-                this.IsScisored = false;
+                this.IsScissored = false;
                 this.SalePrice = this.CachedReference.SalePrice;
                 this.RequiredLevel = this.CachedReference.RequiredLevel;
 
@@ -492,7 +492,7 @@ namespace Destiny.Maple
                 this.IsCash = ((string)datum["flags"]).Contains("cash_item");
                 this.OnlyOne = (sbyte)datum["max_possession_count"] > 0;
                 this.IsTradeBlocked = ((string)datum["flags"]).Contains("no_trade");
-                this.IsScisored = false;
+                this.IsScissored = false;
                 this.SalePrice = (int)datum["price"];
                 this.RequiredLevel = (byte)datum["min_level"];
             }
@@ -524,7 +524,7 @@ namespace Destiny.Maple
             datum["Agility"] = this.Agility;
             datum["Speed"] = this.Speed;
             datum["Jump"] = this.Jump;
-            datum["IsScisored"] = this.IsScisored;
+            datum["IsScissored"] = this.IsScissored;
             datum["PreventsSlipping"] = this.PreventsSlipping;
             datum["PreventsColdness"] = this.PreventsColdness;
             datum["IsStored"] = false;

--- a/src/Maple/Movements.cs
+++ b/src/Maple/Movements.cs
@@ -16,12 +16,12 @@ namespace Destiny.Maple
         Unknown7,
         Unknown8,
         Unknown9,
-        Unknown10,
-        Unknown11,
+        Equipment,
+        Chair,
         Unknown12,
         Unknown13,
         Unknown14,
-        Unknown15,
+        JumpDown,
         Unknown16,
         Unknown17,
         Unknown18,
@@ -72,7 +72,7 @@ namespace Destiny.Maple
                 {
                     case MovementType.Normal:
                     case MovementType.Unknown5:
-                    case MovementType.Unknown15:
+                    case MovementType.JumpDown:
                     case MovementType.Unknown17:
                         {
                             movement.Position = iPacket.ReadPoint();
@@ -80,7 +80,7 @@ namespace Destiny.Maple
                             movement.Foothold = iPacket.ReadShort();
                             this.LastFoothold = movement.Foothold;
 
-                            if (movement.Type != MovementType.Unknown15)
+                            if (movement.Type != MovementType.JumpDown)
                             {
                                 movement.Stance = iPacket.ReadByte();
                                 movement.Duration = iPacket.ReadShort();
@@ -110,7 +110,7 @@ namespace Destiny.Maple
                     case MovementType.Unknown7:
                     case MovementType.Unknown8:
                     case MovementType.Unknown9:
-                    case MovementType.Unknown11:
+                    case MovementType.Chair:
                         {
                             movement.Position = iPacket.ReadPoint();
                             movement.Foothold = iPacket.ReadShort();
@@ -126,7 +126,7 @@ namespace Destiny.Maple
                         }
                         break;
 
-                    case MovementType.Unknown10:
+                    case MovementType.Equipment:
                         {
                             movement.Statistic = iPacket.ReadByte();
                         }
@@ -151,7 +151,7 @@ namespace Destiny.Maple
                 {
                     case MovementType.Normal:
                     case MovementType.Unknown5:
-                    case MovementType.Unknown15:
+                    case MovementType.JumpDown:
                     case MovementType.Unknown17:
                         {
                             oPacket
@@ -159,7 +159,7 @@ namespace Destiny.Maple
                                 .WritePoint(movement.Velocity)
                                 .WriteShort(movement.Foothold);
 
-                            if (movement.Type != MovementType.Unknown15)
+                            if (movement.Type != MovementType.JumpDown)
                             {
                                 oPacket
                                     .WriteByte(movement.Stance)
@@ -191,7 +191,7 @@ namespace Destiny.Maple
                     case MovementType.Unknown7:
                     case MovementType.Unknown8:
                     case MovementType.Unknown9:
-                    case MovementType.Unknown11:
+                    case MovementType.Chair:
                         {
                             oPacket
                                 .WritePoint(movement.Position)
@@ -207,7 +207,7 @@ namespace Destiny.Maple
                         }
                         break;
 
-                    case MovementType.Unknown10:
+                    case MovementType.Equipment:
                         {
                             oPacket.WriteByte(movement.Statistic);
                         }

--- a/src/Maple/Quest.cs
+++ b/src/Maple/Quest.cs
@@ -1,0 +1,174 @@
+﻿using Destiny.Data;
+using Destiny.Maple.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Destiny.Maple
+{
+    public class Quest
+    {
+        public ushort MapleID { get; private set; }
+        public ushort NextQuestID { get; private set; }
+        public sbyte Area { get; private set; }
+        public byte MinimumLevel { get; private set; }
+        public byte MaximumLevel { get; private set; }
+        public short PetCloseness { get; private set; }
+        public sbyte TamingMobLevel { get; private set; }
+        public int RepeatWait { get; private set; }
+        public short Fame { get; private set; }
+        public int TimeLimit { get; private set; }
+        public bool AutoStart { get; private set; }
+        public bool SelectedMob { get; private set; }
+
+        public Dictionary<ushort, QuestStatus> PreRequiredQuests { get; private set; }
+        public Dictionary<ushort, QuestStatus> PostRequiredQuests { get; private set; }
+        public Dictionary<int, short> PreRequiredItems { get; private set; }
+        public Dictionary<int, short> PostRequiredItems { get; private set; }
+        public Dictionary<int, short> PostRequiredKills { get; private set; }
+        public List<short> ValidJobs { get; private set; }
+
+        // Rewards (Start, End)
+        public Tuple<int, int> ExperienceReward { get; private set; }
+        public Tuple<int, int> MesoReward { get; private set; }
+        public Tuple<int, int> PetClosenessReward { get; private set; }
+        public Tuple<bool, bool> PetSpeedReward { get; private set; }
+        public Tuple<int, int> FameReward { get; private set; }
+        public Tuple<int, int> PetSkillReward { get; private set; } //TODO: Use enum instead of int
+        public Tuple<int, int> BuffReward { get; private set; } //TODO: Use enum instead of int
+
+        public List<Tuple<int, short, Gender>> PreItemRewards { get; private set; }
+        public List<Tuple<int, short, Gender>> PostItemRewards { get; private set; }
+        public Dictionary<Skill, Job> PreSkillRewards { get; private set; }
+        public Dictionary<Skill, Job> PostSkillRewards { get; private set; }
+
+        public Quest CachedReference
+        {
+            get
+            {
+                return DataProvider.CachedQuests[this.MapleID];
+            }
+        }
+
+        public Quest NextQuest
+        {
+            get
+            {
+                return this.NextQuestID > 0 ? DataProvider.CachedQuests[this.NextQuestID] : null;
+            }
+        }
+
+        public byte Flags
+        {
+            get
+            {
+                byte flags = 0;
+
+                if (this.AutoStart) flags |= (byte)QuestFlags.AutoStart;
+                if (this.SelectedMob) flags |= (byte)QuestFlags.SelectedMob;
+
+                return flags;
+            }
+        }
+        
+        public Quest(ushort mapleID)
+        {
+            this.MapleID = mapleID;
+            this.NextQuestID = CachedReference.NextQuestID;
+            this.Area = CachedReference.Area;
+            this.MinimumLevel = CachedReference.MinimumLevel;
+            this.MaximumLevel = CachedReference.MaximumLevel;
+            this.PetCloseness = CachedReference.PetCloseness;
+            this.TamingMobLevel = CachedReference.TamingMobLevel;
+            this.RepeatWait = CachedReference.RepeatWait;
+            this.Fame = CachedReference.Fame;
+            this.TimeLimit = CachedReference.TimeLimit;
+            this.AutoStart = CachedReference.AutoStart;
+            this.SelectedMob = CachedReference.SelectedMob;
+
+            this.PreRequiredQuests = CachedReference.PreRequiredQuests;
+            this.PostRequiredQuests = CachedReference.PostRequiredQuests;
+            this.PreRequiredItems = CachedReference.PreRequiredItems;
+            this.PostRequiredItems = CachedReference.PostRequiredItems;
+            this.PostRequiredKills = CachedReference.PostRequiredKills;
+
+            this.ExperienceReward = CachedReference.ExperienceReward;
+            this.MesoReward = CachedReference.MesoReward;
+            this.PetClosenessReward = CachedReference.PetClosenessReward;
+            this.PetSpeedReward = CachedReference.PetSpeedReward;
+            this.FameReward = CachedReference.FameReward;
+            this.PetSkillReward = CachedReference.PetSkillReward;
+            this.BuffReward = CachedReference.BuffReward;
+
+            this.PreItemRewards = CachedReference.PreItemRewards;
+            this.PostItemRewards = CachedReference.PostItemRewards;
+            this.PreSkillRewards = CachedReference.PreSkillRewards;
+            this.PostSkillRewards = CachedReference.PostSkillRewards;
+
+            this.ValidJobs = CachedReference.ValidJobs;
+        }
+
+        public Quest(Datum datum, Datums requests, Datums rewards, Datums jobs)
+        {
+            this.MapleID = (ushort)datum["questid"];
+            this.NextQuestID = (ushort)datum["next_quest"];
+            this.Area = (sbyte)datum["quest_area"];
+            this.MinimumLevel = (byte)datum["min_level"];
+            this.MaximumLevel = (byte)datum["max_level"];
+            this.PetCloseness = (short)datum["pet_closeness"];
+            this.TamingMobLevel = (sbyte)datum["taming_mob_level"];
+            this.RepeatWait = (int)datum["repeat_wait"];
+            this.Fame = (short)datum["fame"];
+            this.TimeLimit = (int)datum["time_limit"];
+            this.AutoStart = datum["flags"].ToString().Contains("auto_start");
+            this.SelectedMob = datum["flags"].ToString().Contains("selected_mob");
+
+            this.PreRequiredQuests  = requests.Where(x => (string)x["request_type"] == "quest" && (string)x["quest_state"] == "start")
+                                              .Select(x => new { objectid = (int)x["objectid"], quantity = (short)x["quantity"] })
+                                              .ToDictionary(x => (ushort)x.objectid, x => (QuestStatus)x.quantity);
+            this.PostRequiredQuests = requests.Where(x => (string)x["request_type"] == "quest" && (string)x["quest_state"] == "end")
+                                              .Select(x => new { objectid = (int)x["objectid"], quantity = (short)x["quantity"] })
+                                              .ToDictionary(x => (ushort)x.objectid, x => (QuestStatus)x.quantity);
+            this.PreRequiredItems   = requests.Where(x => (string)x["request_type"] == "item" && (string)x["quest_state"] == "start")
+                                              .Select(x => new { objectid = (int)x["objectid"], quantity = (short)x["quantity"] })
+                                              .ToDictionary(x => x.objectid, x => x.quantity);
+            this.PostRequiredItems  = requests.Where(x => (string)x["request_type"] == "item" && (string)x["quest_state"] == "end")
+                                              .Select(x => new { objectid = (int)x["objectid"], quantity = (short)x["quantity"] })
+                                              .ToDictionary(x => x.objectid, x => x.quantity);
+            this.PostRequiredKills  = requests.Where(x => (string)x["request_type"] == "mob" && (string)x["quest_state"] == "end")
+                                              .Select(x => new { objectid = (int)x["objectid"], quantity = (short)x["quantity"] })
+                                              .ToDictionary(x => x.objectid, x => x.quantity);
+            
+            this.ExperienceReward   = new Tuple<int, int>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "exp" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0),
+                                                          (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "exp" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0));
+            this.MesoReward         = new Tuple<int, int>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "mesos" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0),
+                                                          (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "mesos" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0));
+            this.PetClosenessReward = new Tuple<int, int>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "pet_closeness" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0),
+                                                          (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "pet_closeness" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0));
+            this.PetSpeedReward     = new Tuple<bool, bool>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "pet_speed" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0) > 0,
+                                                            (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "pet_speed" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0) > 0);
+            this.FameReward         = new Tuple<int, int>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "fame" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0),
+                                                          (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "fame" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0));
+            this.PetSkillReward     = new Tuple<int, int>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "pet_skill" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0),
+                                                          (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "pet_skill" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0));
+            this.BuffReward         = new Tuple<int, int>((int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "buff" && (string)x["quest_state"] == "start")?["rewardid"] ?? 0),
+                                                          (int)(rewards.SingleOrDefault(x => (string)x["reward_type"] == "buff" && (string)x["quest_state"] == "end")?["rewardid"] ?? 0));
+
+            this.PreItemRewards     = rewards.Where(x => (string)x["reward_type"] == "item" && (string)x["quest_state"] == "start")
+                                             .Select(x => new Tuple<int, short, Gender>((int)x["rewardid"], (short)x["quantity"], (Gender)Enum.Parse(typeof(Gender), ((string)x["gender"]).ToCamel())))
+                                             .ToList();
+            this.PostItemRewards    = rewards.Where(x => (string)x["reward_type"] == "item" && (string)x["quest_state"] == "end")
+                                             .Select(x => new Tuple<int, short, Gender>((int)x["rewardid"], (short)x["quantity"], (Gender)Enum.Parse(typeof(Gender), ((string)x["gender"]).ToCamel())))
+                                             .ToList();
+            //TODO: Add a constructor on Skill so we can create instances here
+            //this.PreSkillRewards    = rewards.Where(x => (string)x["reward_type"] == "skill" && (string)x["quest_state"] == "start")
+            //                                 .Select(x => new { rewardid = (int)x["rewardid"], quantity = (short)x["quantity"], master_level = (short)x["master_level"], job = (short)x["job"] })
+            //                                 .ToDictionary(x => new Skill(x.rewardid, x.quantity, x.master_level), x => (Job)x.job);
+            //this.PostSkillRewards   = rewards.Where(x => (string)x["reward_type"] == "skill" && (string)x["quest_state"] == "end")
+            //                                 .Select(x => new { rewardid = (int)x["rewardid"], quantity = (short)x["quantity"], master_level = (short)x["master_level"], job = (short)x["job"] })
+            //                                 .ToDictionary(x => new Skill(x.rewardid, x.quantity, x.master_level), x => (Job)x.job);
+
+            this.ValidJobs = jobs.Select(x => (short)x["valid_jobid"]).ToList();
+        }
+    }
+}

--- a/src/Network/MapleClient.cs
+++ b/src/Network/MapleClient.cs
@@ -650,6 +650,8 @@ namespace Destiny
             Gender gender = (Gender)iPacket.ReadByte();
 
             bool error = false;
+            
+            //TODO: Validate against data in MCDB instead of hard-coding it all here
 
             //Name constraints
             //TODO: Check if name violates forbidden words

--- a/src/Setup.cs
+++ b/src/Setup.cs
@@ -163,7 +163,7 @@ namespace Destiny
                               `Agility` smallint(6) NOT NULL DEFAULT '0',
                               `Speed` smallint(6) NOT NULL DEFAULT '0',
                               `Jump` smallint(6) NOT NULL DEFAULT '0',
-                              `IsScisored` tinyint(1) unsigned NOT NULL DEFAULT '0',
+                              `IsScissored` tinyint(1) unsigned NOT NULL DEFAULT '0',
                               `PreventsSlipping` tinyint(1) unsigned NOT NULL DEFAULT '0',
                               `PreventsColdness` tinyint(1) unsigned NOT NULL DEFAULT '0',
                               `IsStored` tinyint(1) unsigned NOT NULL DEFAULT '0',


### PR DESCRIPTION
This should load most of the data about quests from MCDB right when the project boots up, just as is done with maps. The quest operation packet(s) are still unimplemented, but at least the data is loaded so it can be worked with.

Also implemented the remaining commands so that all the commands in the code right now should work. !map still needs a little work to allow typing names instead of IDs, but the rest should operate pretty much as expected.