### PR TITLE
Fix V3008

### DIFF
--- a/src/WvsGame/Maple/Item.cs
+++ b/src/WvsGame/Maple/Item.cs
@@ -616,7 +616,7 @@ namespace Destiny.Maple
             this.CWeaponAttack = (short)datum["weapon_attack"];
             this.CMagicAttack = (short)datum["magic_attack"];
             this.CWeaponDefense = (short)datum["weapon_defense"];
-            this.CMagicAttack = (short)datum["magic_attack"];
+            this.CMagicDefense = (short)datum["magic_defense"];
             this.CAccuracy = (short)datum["accuracy"];
             this.CAvoid = (short)datum["avoid"];
             this.CSpeed = (short)datum["speed"];


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- The 'this.CMagicAttack' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 619, 617. WvsGame Item.cs