### PR TITLE
Fix V3127

### DIFF
--- a/src/WvsGame/Maple/Buff.cs
+++ b/src/WvsGame/Maple/Buff.cs
@@ -226,7 +226,7 @@ namespace Destiny.Maple
 
             if (skill.MagicDefense > 0)
             {
-                this.SecondaryStatups.Add(SecondaryBuffStat.MagicDefense, skill.MagicAttack);
+                this.SecondaryStatups.Add(SecondaryBuffStat.MagicDefense, skill.MagicDefense);
             }
 
             if (skill.Accuracy > 0)


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- Two similar code fragments were found. Perhaps, this is a typo and 'MagicDefense' variable should be used instead of 'MagicAttack' WvsGame Buff.cs